### PR TITLE
Add instructions to prevent database timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Install the package using pip via:
 
     pip install django-sec
 
-then add `django_sec` to your `INSTALLED_APPS` and run:
+add `django_sec` to your `INSTALLED_APPS` and`'CONN_MAX_AGE': 0,` to your default `DATABASES` and run:
 
     python manage.py migrate django_sec
+
 
 Usage
 -----


### PR DESCRIPTION
You need a django config like this to prevent a SQL timeout error during index imports.

```
DATABASES = {
	'default': {
		'ENGINE': 'django.db.backends.sqlite3',
		'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
		'CONN_MAX_AGE': 0,
	}
}
```